### PR TITLE
Support literal arrays + more tests for syntactic sugar

### DIFF
--- a/lib/s.js
+++ b/lib/s.js
@@ -12,15 +12,23 @@ function s(spec) {
   }
 
   return function(path, obj) {
-    if (typeof path === 'object' && obj === undefined) {
+
+    // support for matcher(value)
+    // so people don't have to call matcher('', value) at the top level
+    if (arguments.length === 1) {
       obj = path;
       path = '';
     }
+
+    // syntactic sugar
+    // wrap different primitives into the corresponding matcher
     var err = null;
     if (typeof spec === 'function') {
       err = spec(path, obj);
+    } else if (util.isArray(spec)) {
+      err = s.array(spec[0])(path, obj);
     } else if (typeof spec === 'object') {
-      err = s.object(spec)(path, obj)
+      err = s.object(spec)(path, obj);
     } else if (typeof spec === 'string') {
       err = s[spec]()(path, obj);
     }

--- a/test/syntactic-sugar.spec.js
+++ b/test/syntactic-sugar.spec.js
@@ -3,23 +3,70 @@ var s = require('../lib/index');
 describe('syntactic sugar', function() {
 
   it('can use the matchers name instead of the function', function() {
+    var schema = s('string');
+    schema(3).should.eql([{
+      path: '',
+      value: 3,
+      message: 'should be a string'
+    }]);
+  });
 
+  it('can use object litterals instead of the object matcher', function() {
+    var schema = s({
+      name: s.string(),
+      age:  s.number()
+    });
+    schema({
+      name: 'bob',
+      age: 'foo'
+    }).should.eql([{
+      path: 'age',
+      value: 'foo',
+      message: 'should be a number'
+    }]);
+  });
+
+  it('can use matcher names inside object litterals', function() {
     var schema = s({
       name: 'string',
       age:  'number'
     });
-
     schema({
       name: 'bob',
       age: 'foo'
-    }).should.eql([
-      {
-        path: 'age',
-        value: 'foo',
-        message: 'should be a number'
-      }
-    ]);
+    }).should.eql([{
+      path: 'age',
+      value: 'foo',
+      message: 'should be a number'
+    }]);
+  });
 
+  it('can use custom functions directly', function() {
+    var schema = s({
+      number:  function(value) {
+        if (value % 2) return 'should be an even number';
+      }
+    });
+    schema({
+      number: 3,
+    }).should.eql([{
+      path: 'number',
+      value: 3,
+      message: 'should be an even number'
+    }]);
+  });
+
+  it('can use the array litteral notation', function() {
+    var schema = s({
+      names: ['string']
+    });
+    schema({
+      names: ['hello', 123],
+    }).should.eql([{
+      path: 'names[1]',
+      value: 123,
+      message: 'should be a string'
+    }]);
   });
 
 });


### PR DESCRIPTION
@nguyenchr this adds support for 

``` js
s({
  names: ['string']
  addresses: [{
    city: 'string'
  }]
})
```
