### PR TITLE
Add test coverage with Blanket.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+/node_modules
+/coverage.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "0.10"
+script: "make travis"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+test:
+	@./node_modules/.bin/mocha
+
+coverage:
+	@BLANKET=true ./node_modules/.bin/mocha --reporter html-cov > coverage.html
+
+travis:
+	@BLANKET=true ./node_modules/.bin/mocha --reporter travis-cov
+
+.PHONY: test coverage travis

--- a/package.json
+++ b/package.json
@@ -6,13 +6,24 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+  },
+  "config": {
+    "blanket": {
+      "pattern": "lib",
+      "data-cover-never": "node_modules"
+    },
+    "travis-cov": {
+      "threshold": 95
+    }
   },
   "devDependencies": {
     "mocha": "~1.21.3",
     "should": "~4.0.4",
     "cli-table": "~0.3.0",
-    "format-number": "~1.0.2"
+    "format-number": "~1.0.2",
+    "blanket": "~1.1.6",
+    "travis-cov": "~0.2.5",
+    "require-dir": "~0.1.0"
   },
   "dependencies": {
     "lodash": "~2.4.1",

--- a/test/performance.spec.js
+++ b/test/performance.spec.js
@@ -45,7 +45,7 @@ describe('Performance', function() {
     run(table, 100);
     run(table, 1000);
     run(table, 10000);
-    console.log('\n' + table.toString() + '\n');
+    console.error('\n' + table.toString() + '\n');
   });
 
   function run(table, count) {

--- a/test/spec-helpers.js
+++ b/test/spec-helpers.js
@@ -1,4 +1,12 @@
-var should = require('should');
+var should     = require('should');
+var blanket    = require('blanket');
+var requireDir = require('require-dir');
+
+// only instrument the code if running test coverage
+if (process.env['BLANKET']) {
+  blanket({});
+  requireDir(__dirname + '/../lib', {recurse: true, duplicates: true});
+}
 
 should.Assertion.prototype.error = function(regex) {
   var found = this.obj.filter(function(err) {


### PR DESCRIPTION
@TabDigital/api : automatically calculate test coverage.
Now has a `Makefile` with the following targets:
- `make test` to run the tests as usual
- `make coverage` to calculate test coverage (output to `coverage.html`)
  - this is a separate task since we don't want coverage to affect the performance tests
- `make travis` for Travis-CI integration
