### PR TITLE
Relationships

### DIFF
--- a/lib/matcher.js
+++ b/lib/matcher.js
@@ -26,13 +26,13 @@ Matcher.prototype.setName = function(name) {
   this.name = name;
 };
 
-Matcher.prototype.match = function(path, value) {
+Matcher.prototype.match = function(path, value, relationships) {
   if (arguments.length === 1) {
     value = path;
     path = '';
   }
   if (this.optional && missing(value)) { return []; }
-  var errors = this._match(path, value);
+  var errors = this._match(path, value, relationships);
   if (!errors) { return []; }
   if (typeof errors === 'string') { return [{path: path, value: value, message: errors}]; }
   else { return errors; }

--- a/lib/matchers/objectWithOnly.js
+++ b/lib/matchers/objectWithOnly.js
@@ -1,6 +1,7 @@
 var _ = require('lodash');
 var factory = require('../factory');
 var s = require('../strummer');
+var relate = require('../relate');
 
 module.exports = factory({
   initialize: function(spec) {
@@ -12,7 +13,7 @@ module.exports = factory({
     this.matcher = new s.object(this.spec);
   },
 
-  match: function (path, val) {
+  match: function (path, val, relationships) {
     var objError = this.matcher.match(path, val);
     var key;
     if (objError.length > 0) {
@@ -28,6 +29,13 @@ module.exports = factory({
           });
         }
       }
+
+      if(relationships) {
+	errors.concat(
+	  relationships.validate(spec, path, val, relationships)
+        );
+      }
+
       return _.flatten(errors);
     }
   },

--- a/lib/matchers/objectWithOnly.js
+++ b/lib/matchers/objectWithOnly.js
@@ -14,7 +14,7 @@ module.exports = factory({
   },
 
   match: function (path, val, relationships) {
-    var objError = this.matcher.match(path, val);
+    var objError = this.matcher.match(path, val, relationships);
     var key;
     if (objError.length > 0) {
       return objError;
@@ -30,9 +30,9 @@ module.exports = factory({
         }
       }
 
-      if(relationships) {
-	errors.concat(
-	  relationships.validate(spec, path, val, relationships)
+      if (relationships) {
+         errors = errors.concat(
+          relate.validate(this.spec, path, val, relationships)
         );
       }
 

--- a/lib/relate.js
+++ b/lib/relate.js
@@ -1,0 +1,43 @@
+exports.validate = function (spec, path, val, relationships) {
+  var errors = [];
+  relationships.forEach(function (relations) {
+    var values = relations.values
+    var relationType = relations.type
+
+    var validOr = false
+
+    values.forEach(function (relation) {
+      if (!spec[relation]) {
+        errors.push({
+          path: path,
+          value: relation,
+          message: relation + ' does not exist in the schema'
+        });
+      } else if (
+        relationType === 'and' &&
+        !Object.keys(val).includes(relation)
+      ) {
+        errors.push({
+          path: path,
+          value: values,
+          message: JSON.stringify(values) + ' are related and therefore required'
+        })
+      } else if (
+        relationType === 'or' &&
+        Object.keys(val).includes(relation)
+      ) {
+        validOr = true
+      }
+    })
+
+    if (relationType === 'or' && !validOr) {
+      errors.push({
+        path: path,
+        value: values,
+        message: 'at least one of ' + JSON.stringify(values) + ' are required'
+      })
+    }
+  })
+
+  return errors
+}

--- a/test/matchers/objectWithOnly.spec.js
+++ b/test/matchers/objectWithOnly.spec.js
@@ -50,9 +50,9 @@ describe('objectWithOnly object matcher', function() {
       age:  new number()
     });
 
-    schema.match('', {name: 'bob', age: 21, email: "bob@email.com"}).should.eql([{
+    schema.match('', {name: 'bob', age: 21, email: 'bob@email.com'}).should.eql([{
       path: 'email',
-      value: "bob@email.com",
+      value: 'bob@email.com',
       message: 'should not exist'
     }])
   });
@@ -70,8 +70,8 @@ describe('objectWithOnly object matcher', function() {
       name: 'bob',
       age: 21,
       address: {
-        email: "bob@email.com",
-        home: "21 bob street"
+        email: 'bob@email.com',
+        home: '21 bob street'
       }
     }
 
@@ -142,5 +142,58 @@ describe('objectWithOnly object matcher', function() {
       additionalProperties: false
     });
   });
-  
+
+  it('handles valid relationships', function() {
+    var schema = new objectWithOnly({
+      name: new string(),
+      street_number: new number({ optional: true }),
+      street_post_code: new number({ optional: true })
+    })
+
+    var bob = {
+      name: 'bob',
+      street_number: 12,
+      street_post_code: 2001
+    }
+
+    var relationships = [
+      {
+        type: 'and',
+        values: ['street_number', 'street_post_code']
+      }
+    ]
+
+    schema.match('', bob, relationships).should.eql([])
+  });
+
+  it('gets errors on invalid relationships', function() {
+    var schema = new objectWithOnly({
+      name: new string(),
+      street_number: new number({ optional: true }),
+      street_post_code: new number({ optional: true })
+    })
+
+    var bob = {
+      name: 'bob',
+      street_number: 12
+    }
+
+    var relationships = [
+      {
+        type: 'and',
+        values: ['street_number', 'street_post_code']
+      }
+    ]
+
+    schema.match('', bob, relationships).should.eql([
+      {
+        message: '["street_number","street_post_code"] are related and therefore required',
+        path: '',
+        value: [
+          'street_number',
+          'street_post_code'
+        ]
+      }
+    ])
+  });
 });

--- a/test/relate.spec.js
+++ b/test/relate.spec.js
@@ -22,7 +22,7 @@ describe('relate', function () {
     ])
   })
 
-  it('should return no errors on valid relationship', function () {
+  it('should return no errors on valid AND relationship', function () {
     var spec = {
       param: 'should exist',
       param2: 'will exist'
@@ -36,6 +36,24 @@ describe('relate', function () {
     ]
 
     var errors = relate.validate(spec, '', { param: 'value', param2: 'value2' }, relationships)
+
+    errors.should.deepEqual([])
+  })
+
+  it('should return no errors on valid OR relationship', function () {
+    var spec = {
+      param: 'could exist',
+      param2: 'could exist'
+    }
+
+    var relationships = [
+      {
+        type: 'or',
+        values: ['param', 'param2']
+      }
+    ]
+
+    var errors = relate.validate(spec, '', { param2: 'value2' }, relationships)
 
     errors.should.deepEqual([])
   })
@@ -66,8 +84,8 @@ describe('relate', function () {
 
   it('should throw errors on missing or relation', function () {
     var spec = {
-      param: 'should exist',
-      param2: 'will exist',
+      param: 'could exist',
+      param2: 'could exist',
       param3: 'wont exist'
     }
 

--- a/test/relate.spec.js
+++ b/test/relate.spec.js
@@ -1,0 +1,91 @@
+var relate = require('../lib/relate');
+
+describe('relate', function () {
+  it('throws an error if relation is not in the schema', function () {
+    var spec = {
+      param: 'should exist'
+    }
+
+    var errors = relate.validate(
+      spec,
+      '',
+      {},
+      [{ values: ['param2'] }]
+    )
+
+    errors.should.deepEqual([
+      {
+        path: '',
+        value: 'param2',
+        message: 'param2 does not exist in the schema'
+      }
+    ])
+  })
+
+  it('should return no errors on valid relationship', function () {
+    var spec = {
+      param: 'should exist',
+      param2: 'will exist'
+    }
+
+    var relationships = [
+      {
+        type: 'and',
+        values: ['param', 'param2']
+      }
+    ]
+
+    var errors = relate.validate(spec, '', { param: 'value', param2: 'value2' }, relationships)
+
+    errors.should.deepEqual([])
+  })
+
+  it('should throw errors on missing and relation', function () {
+    var spec = {
+      param: 'should exist',
+      param2: 'will exist'
+    }
+
+    var relationships = [
+      {
+        type: 'and',
+        values: ['param', 'param2']
+      }
+    ]
+
+    var errors = relate.validate(spec, '', { param: 'value' }, relationships)
+
+    errors.should.deepEqual([
+      {
+        path: '',
+        value: ['param', 'param2'],
+        message: '["param","param2"] are related and therefore required'
+      }
+    ])
+  })
+
+  it('should throw errors on missing or relation', function () {
+    var spec = {
+      param: 'should exist',
+      param2: 'will exist',
+      param3: 'wont exist'
+    }
+
+    var relationships = [
+      {
+        type: 'or',
+        values: ['param', 'param2']
+      }
+    ]
+
+    var errors = relate.validate(spec, '', { param3: 'value' }, relationships)
+
+    errors.should.deepEqual([
+      {
+        path: '',
+        value: ['param', 'param2'],
+        message: 'at least one of ["param","param2"] are required'
+      }
+    ])
+  })
+})


### PR DESCRIPTION
I'm adding this as we have situations where a schema has related optional fields. 

Use cases:

Both fields are optional but if one exists they must both exist. 

```
// AND
{
   street_number: 1,
   post_code: 2
}
```

Both fields are optional but one must exist.

```
// OR
{
   phone_number: 1,
   email_address: 2
}
```

The above fields are optional but one must exist. 