### PR TITLE
use `String()` instead of `.toString()`

### DIFF
--- a/lib/matchers/value.js
+++ b/lib/matchers/value.js
@@ -12,7 +12,7 @@ module.exports = factory({
   },
   match: function(path, value) {
     if (value !== this.expectedValue) {
-      return 'should strict equal ' + this.expectedValue.toString();
+      return 'should strict equal ' + String(this.expectedValue);
     }
   },
   toJSONSchema: function () {

--- a/test/matchers/value.spec.js
+++ b/test/matchers/value.spec.js
@@ -31,6 +31,15 @@ describe('equals matcher', function() {
   });
 
   describe('when strict equality on primitive', function() {
+    it('passes for null', function() {
+      new ValueMatcher(null).match('', null).should.not.have.error();
+      new ValueMatcher(null).match('', 123).should.eql([{
+        path: '',
+        value: 123,
+        message: 'should strict equal null'
+      }])
+    });
+
     it('passes for boolean', function() {
       new ValueMatcher(true).match('', true).should.not.have.error();
     });


### PR DESCRIPTION
if `expectedValue` is `null` `_.isObject` returns true, however `null.toString()` doesn't work while `String(null) does.