### PR TITLE
Only add version if it exists

### DIFF
--- a/lib/matchers/uuid.js
+++ b/lib/matchers/uuid.js
@@ -22,9 +22,13 @@ module.exports = factory({
     }
   },
   toJSONSchema: function () {
+    var format = 'uuid'
+    if (this.version) {
+      format += '-v' + this.version
+    }
     var schema = {
       type: 'string',
-      format: 'uuid-v' + this.version
+      format: format
     };
     if (this.description) {
       schema.description = this.description;

--- a/test/matchers/uuid.spec.js
+++ b/test/matchers/uuid.spec.js
@@ -42,6 +42,10 @@ describe('uuid matcher', function() {
     new uuid({version: 4}).toJSONSchema().should.eql({ type: 'string', format: 'uuid-v4' });
   });
 
+  it('generate non version specific format of uuid json schema', function() {
+    new uuid().toJSONSchema().should.eql({ type: 'string', format: 'uuid' });
+  });
+
   it('generates a json schema with description option', function() {
     new uuid({version: 4, description: 'Lorem ipsum'}).toJSONSchema().should.eql({ type: 'string', format: 'uuid-v4', description: 'Lorem ipsum' });
   });


### PR DESCRIPTION
When you don't specify a version, it would previously have format `uuid-vundefined` now it has `uuid`