### PR TITLE
Add hashmap json schema

### DIFF
--- a/lib/matchers/hashmap.js
+++ b/lib/matchers/hashmap.js
@@ -6,6 +6,7 @@ var s       = require('../strummer');
 
 module.exports = factory({
   initialize: function(opts) {
+    this.opts = opts || {};
     var matchers = { keys: null, values: null };
     if (opts instanceof Matcher) {
       matchers.values = opts;
@@ -17,6 +18,7 @@ module.exports = factory({
     }
 
     this.matchers = matchers;
+    this.description = this.opts.description;
   },
 
   match: function(path, obj) {
@@ -37,5 +39,21 @@ module.exports = factory({
     }
 
     return _.compact(_.flattenDeep(errors));
+  },
+  toJSONSchema: function() {
+    var self = this;
+
+    var schema = {
+      type: 'object'
+    };
+
+    if (self.matchers.values) {
+      schema.additionalProperties = self.matchers.values.toJSONSchema();
+    }
+
+    if (this.description) {
+      schema.description = this.description;
+    }
+    return schema;
   }
 });

--- a/test/matchers/hashmap.spec.js
+++ b/test/matchers/hashmap.spec.js
@@ -84,4 +84,42 @@ describe('hashmap matcher', function() {
 
   });
 
+  describe('jsonschema', function() {
+    it('creates json schema', function() {
+      var matcher = new hashmap();
+
+      matcher.toJSONSchema().should.eql({ type: 'object' });
+    });
+
+    it('creates json schema when value shema is defined', function() {
+      var matcher = new hashmap(new s.string());
+
+      matcher.toJSONSchema().should.eql({
+        type: 'object',
+        additionalProperties: { type: 'string' }
+      });
+    });
+
+    it('creates json schema when keys and values are defined', function() {
+      var matcher = new hashmap({
+        keys: /n/,
+        values: new s.number({max: 1})
+      });
+
+      matcher.toJSONSchema().should.eql({
+        type: 'object',
+        additionalProperties: { type: 'number', maximum: 1 }
+      });
+    });
+
+    it('creates json schema with description', function() {
+      var matcher = new hashmap({ description: 'Lorem ipsum' });
+
+      matcher.toJSONSchema().should.eql({
+        type: 'object',
+        description: 'Lorem ipsum'
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Using object with additionalProperties schema as suggested here

https://stackoverflow.com/questions/38088771/swagger-yaml-schema-definition-for-object-without-a-fixed-property-list

seems to work ok in swagger UI

![image](https://user-images.githubusercontent.com/5554109/64293361-c605b500-cfaf-11e9-9db1-34b12f3a2f46.png)

```js
airports: s.hashmap({
  keys: airportCode,
  values: s.objectWithOnly({
    code: airportCode,
    name: s.string({ description: 'Display name of the airport' }),
    latitude: s.number({ description: 'Latitude value of the airport' }),
    longitude: s.number({ description: 'Longitude value of the airport' })
  })
}),
```